### PR TITLE
Final touch up and edits

### DIFF
--- a/AEPCampaignClassic.xcodeproj/project.pbxproj
+++ b/AEPCampaignClassic.xcodeproj/project.pbxproj
@@ -67,7 +67,7 @@
 		D609F883284AC7CE0007EAA7 /* TestableExtensionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = D609F876284AC7CE0007EAA7 /* TestableExtensionRuntime.swift */; };
 		D609F884284AC7CE0007EAA7 /* MockNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = D609F877284AC7CE0007EAA7 /* MockNetworking.swift */; };
 		D609F888284AC7CE0007EAA7 /* MockExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D609F87B284AC7CE0007EAA7 /* MockExtension.swift */; };
-		D609F890284AC7E60007EAA7 /* CampaignClassicFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D609F88F284AC7E60007EAA7 /* CampaignClassicFunctionalTests.swift */; };
+		D609F890284AC7E60007EAA7 /* CampaignClassicIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D609F88F284AC7E60007EAA7 /* CampaignClassicIntegrationTests.swift */; };
 		D62CB118284AC0020008C0F2 /* AEPCampaignClassic.h in Headers */ = {isa = PBXBuildFile; fileRef = D62CB117284AC0020008C0F2 /* AEPCampaignClassic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D6E12ADE284A5EA100C7FEFE /* CampaignClassic+PublicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E12AD7284A5EA100C7FEFE /* CampaignClassic+PublicAPI.swift */; };
 		D6E12AE0284A5EA100C7FEFE /* CampaignClassicConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E12AD9284A5EA100C7FEFE /* CampaignClassicConstants.swift */; };
@@ -203,7 +203,7 @@
 		D609F876284AC7CE0007EAA7 /* TestableExtensionRuntime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestableExtensionRuntime.swift; sourceTree = "<group>"; };
 		D609F877284AC7CE0007EAA7 /* MockNetworking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworking.swift; sourceTree = "<group>"; };
 		D609F87B284AC7CE0007EAA7 /* MockExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockExtension.swift; sourceTree = "<group>"; };
-		D609F88F284AC7E60007EAA7 /* CampaignClassicFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampaignClassicFunctionalTests.swift; sourceTree = "<group>"; };
+		D609F88F284AC7E60007EAA7 /* CampaignClassicIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampaignClassicIntegrationTests.swift; sourceTree = "<group>"; };
 		D62CB117284AC0020008C0F2 /* AEPCampaignClassic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AEPCampaignClassic.h; sourceTree = "<group>"; };
 		D655170E2667F6FB00A152CF /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		D655170F2667F72600A152CF /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -443,7 +443,7 @@
 		D609F872284AC7CE0007EAA7 /* FunctionalTests */ = {
 			isa = PBXGroup;
 			children = (
-				D609F88F284AC7E60007EAA7 /* CampaignClassicFunctionalTests.swift */,
+				D609F88F284AC7E60007EAA7 /* CampaignClassicIntegrationTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -895,7 +895,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D609F890284AC7E60007EAA7 /* CampaignClassicFunctionalTests.swift in Sources */,
+				D609F890284AC7E60007EAA7 /* CampaignClassicIntegrationTests.swift in Sources */,
 				B611769728B8A174009C6ADE /* TestConstants.swift in Sources */,
 				B655521128B54D2B00E8C445 /* TestHelper.swift in Sources */,
 				D609F888284AC7CE0007EAA7 /* MockExtension.swift in Sources */,

--- a/AEPCampaignClassic/Sources/CampaignClassic+PublicAPI.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassic+PublicAPI.swift
@@ -22,7 +22,7 @@ public extension CampaignClassic {
     ///
     /// - Parameters:
     ///    - token : A unique device token received after registering your app with APNs servers
-    ///    - userKey : An optional `string` containing the user identifier
+    ///    - userKey : An optional `String` containing the user identifier
     ///    - additionalParameters : a dictionary of custom key-value pairs to be sent along with the registration call
     static func registerDevice(token: Data, userKey: String?, additionalParameters: [String: Any]?) {
 

--- a/AEPCampaignClassic/Sources/CampaignClassic+PublicAPI.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassic+PublicAPI.swift
@@ -22,13 +22,13 @@ public extension CampaignClassic {
     ///
     /// - Parameters:
     ///    - token : A unique device token received after registering your app with APNs servers
-    ///    - userKey : A `string` containing the user identifier
+    ///    - userKey : An optional `string` containing the user identifier
     ///    - additionalParameters : a dictionary of custom key-value pairs to be sent along with the registration call
-    static func registerDevice(token: Data, userKey: String, additionalParameters: [String: Any]?) {
+    static func registerDevice(token: Data, userKey: String?, additionalParameters: [String: Any]?) {
 
         var eventData = [CampaignClassicConstants.EventDataKeys.CampaignClassic.REGISTER_DEVICE: true,
                          CampaignClassicConstants.EventDataKeys.CampaignClassic.DEVICE_TOKEN: token.hexDescription,
-                         CampaignClassicConstants.EventDataKeys.CampaignClassic.USER_KEY: userKey] as [String: Any]
+                         CampaignClassicConstants.EventDataKeys.CampaignClassic.USER_KEY: userKey ?? ""] as [String: Any]
 
         // attach additional parameters only if they are available
         if let additionalParameters = additionalParameters {
@@ -81,6 +81,6 @@ public extension CampaignClassic {
 private extension Data {
     /// Returns a hex representation of the data
     var hexDescription: String {
-        return reduce("") {$0 + String(format: "%02X", $1)}
+        return reduce("") {$0 + String(format: "%02x", $1)}
     }
 }

--- a/AEPCampaignClassic/Sources/CampaignClassic.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassic.swift
@@ -23,7 +23,7 @@ public class CampaignClassic: NSObject, Extension {
     public var runtime: ExtensionRuntime
     let dispatchQueue: DispatchQueue
 
-    /// following variable is made editable for testing purposes
+    // following variable is made editable for testing purposes
     #if DEBUG
         var registrationManager: RegistrationManager
     #else
@@ -149,25 +149,26 @@ public class CampaignClassic: NSObject, Extension {
                 Log.debug(label: CampaignClassicConstants.LOG_TAG, "Unable to trackNotification, Network Error. Response Code: \(String(describing: connection.responseCode)) URL : \(trackingUrl.absoluteString)")
                 return
             }
-            Log.debug(label: CampaignClassicConstants.LOG_TAG, "TrackNotification success. URL : \(trackingUrl.absoluteString)")
+            let responseMessage = String(data: connection.data ?? Data(), encoding: .utf8) ?? ""
+            Log.debug(label: CampaignClassicConstants.LOG_TAG, "TrackNotification success. Response message: \(responseMessage)")
         })
     }
 
     /// Validates and transforms the broadlogId into the required format
     /// - Parameter broadlogId : the broadlogId string to be validated
     private func transformBroadLogId(_ broadlogId: String) -> String? {
-        /// if this is a valid UUID (v8 messageId format), return the string without modification
+        // if this is a valid UUID (v8 messageId format), return the string without modification
         if let _ = UUID(uuidString: broadlogId) {
             Log.debug(label: CampaignClassicConstants.LOG_TAG, "Track Notification - BroadlogId detected in v8 format: \(broadlogId)")
             return broadlogId
         }
 
-        /// if not a valid UUID and neither in v7 format (Integer), return nil
+        // if not a valid UUID and neither in v7 format (Integer), return nil
         guard let broadLogIdInt = Int(broadlogId) else {
             return nil
         }
 
-        /// return the hex representation of integer for v7 format messageId
+        // return the hex representation of integer for v7 format messageId
         let hexBroadLogId = String(format: "%02X", broadLogIdInt)
         Log.debug(label: CampaignClassicConstants.LOG_TAG, "Track Notification - BroadlogId detected in v7 format: \(hexBroadLogId)")
         return hexBroadLogId

--- a/AEPCampaignClassic/Sources/CampaignClassic.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassic.swift
@@ -149,7 +149,7 @@ public class CampaignClassic: NSObject, Extension {
                 Log.debug(label: CampaignClassicConstants.LOG_TAG, "Unable to trackNotification, Network Error. Response Code: \(String(describing: connection.responseCode)) URL : \(trackingUrl.absoluteString)")
                 return
             }
-            let responseMessage = String(data: connection.data ?? Data(), encoding: .utf8) ?? ""
+            let responseMessage = String(data: connection.data ?? Data(), encoding: .utf8) ?? "Unable to read response message."
             Log.debug(label: CampaignClassicConstants.LOG_TAG, "TrackNotification success. Response message: \(responseMessage)")
         })
     }
@@ -164,14 +164,14 @@ public class CampaignClassic: NSObject, Extension {
         }
 
         // if not a valid UUID and neither in v7 format (Integer), return nil
-        guard let broadLogIdInt = Int(broadlogId) else {
+        guard let broadlogIdInt = Int(broadlogId) else {
             return nil
         }
 
         // return the hex representation of integer for v7 format messageId
-        let hexBroadLogId = String(format: "%02X", broadLogIdInt)
-        Log.debug(label: CampaignClassicConstants.LOG_TAG, "Track Notification - BroadlogId detected in v7 format: \(hexBroadLogId)")
-        return hexBroadLogId
+        let broadlogIdHex = String(format: "%02x", broadlogIdInt)
+        Log.debug(label: CampaignClassicConstants.LOG_TAG, "Track Notification - BroadlogId detected in v7 format: \(broadlogIdHex)")
+        return broadlogIdHex
     }
 
 }

--- a/AEPCampaignClassic/Sources/RegistrationManager.swift
+++ b/AEPCampaignClassic/Sources/RegistrationManager.swift
@@ -134,7 +134,7 @@ class RegistrationManager {
             }
 
             // retrieve the response message from the body
-            let responseMessage = String(data: connection.data ?? Data(), encoding: .utf8) ?? ""
+            let responseMessage = String(data: connection.data ?? Data(), encoding: .utf8) ?? "Unable to read response message."
             Log.debug(label: CampaignClassicConstants.LOG_TAG, "Device Registration success. Saving the hashed registration data. Response message : \(responseMessage)")
             self.hashedRegistrationData = hashedData
         }

--- a/AEPCampaignClassic/Tests/FunctionalTests/CampaignClassicFunctionalTests.swift
+++ b/AEPCampaignClassic/Tests/FunctionalTests/CampaignClassicFunctionalTests.swift
@@ -71,7 +71,7 @@ class CampaignClassicFunctionalTests: XCTestCase {
         
         // verify network payload
         let payload = mockNetwork.cachedNetworkRequests[0].payloadAsString()
-        XCTAssertTrue(payload.contains("registrationToken=70757368546F6B656"))
+        XCTAssertTrue(payload.contains("registrationToken=70757368546f6b656e"))
         XCTAssertTrue(payload.contains("mobileAppUuid=integrationKey&"))
         XCTAssertTrue(payload.contains("userKey=userkey&"))
         XCTAssertTrue(payload.contains("deviceName=\(URLEncoder.encode(value: UIDevice.current.name))&"))
@@ -85,7 +85,7 @@ class CampaignClassicFunctionalTests: XCTestCase {
         
         // verify persisted registered data hash
         // following is the constant hash generated for the given pushToken, userKey and additional data
-        XCTAssertEqual("049dd429b573e8f5bb1b6d805e1785afa24bb48a2489acd397fd8ec15c37d1b7" , datastore.getString(key: TestConstants.DatastoreKeys.TOKEN_HASH))
+        XCTAssertEqual("a40276d0637e4e22d9b41fbe24437e2f5c642c38653b57131cbb3660bfcb745f" , datastore.getString(key: TestConstants.DatastoreKeys.TOKEN_HASH))
     }
     
     func test_registerDevice_whenPrivacyOptedOut() {
@@ -165,7 +165,7 @@ class CampaignClassicFunctionalTests: XCTestCase {
         // verify network call is made
         wait(for: [mockNetwork.connectAsyncCalled], timeout: 1)
         XCTAssertEqual(1, mockNetwork.cachedNetworkRequests.count)
-        XCTAssertEqual("049dd429b573e8f5bb1b6d805e1785afa24bb48a2489acd397fd8ec15c37d1b7" , datastore.getString(key: TestConstants.DatastoreKeys.TOKEN_HASH))
+        XCTAssertEqual("a40276d0637e4e22d9b41fbe24437e2f5c642c38653b57131cbb3660bfcb745f" , datastore.getString(key: TestConstants.DatastoreKeys.TOKEN_HASH))
         
         // reset
         mockNetwork.reset()
@@ -192,7 +192,7 @@ class CampaignClassicFunctionalTests: XCTestCase {
         
         // verify
         XCTAssertEqual(1, mockNetwork.cachedNetworkRequests.count)
-        XCTAssertEqual("049dd429b573e8f5bb1b6d805e1785afa24bb48a2489acd397fd8ec15c37d1b7" , datastore.getString(key: TestConstants.DatastoreKeys.TOKEN_HASH))
+        XCTAssertEqual("a40276d0637e4e22d9b41fbe24437e2f5c642c38653b57131cbb3660bfcb745f" , datastore.getString(key: TestConstants.DatastoreKeys.TOKEN_HASH))
             
         
         // test again
@@ -202,7 +202,7 @@ class CampaignClassicFunctionalTests: XCTestCase {
         wait(for: [mockNetwork.connectAsyncCalled], timeout: 1)
         XCTAssertEqual(2, mockNetwork.cachedNetworkRequests.count)
         // verify that the registration data is changed
-        XCTAssertEqual("999f4058edd26c21d639f81441c6139e4f04130151daa6f756e9f9aabe9e4598" , datastore.getString(key: TestConstants.DatastoreKeys.TOKEN_HASH))
+        XCTAssertEqual("6c78a6175d527e5d620285b86f718cfd524c0a26e65c4a8db5a0f8aa5b67e4f1" , datastore.getString(key: TestConstants.DatastoreKeys.TOKEN_HASH))
     }
     
     

--- a/AEPCampaignClassic/Tests/FunctionalTests/CampaignClassicIntegrationTests.swift
+++ b/AEPCampaignClassic/Tests/FunctionalTests/CampaignClassicIntegrationTests.swift
@@ -29,7 +29,7 @@ class CampaignClassicIntegrationTests: XCTestCase {
     let V8_BROADLOG_ID = UUID().uuidString
     let V7_BROADLOG_ID = "55336"
     let DELIVERY_ID = "deliveryId"
-    let V7_BROADLOG_ID_HEX = "D828"
+    let V7_BROADLOG_ID_HEX = "d828"
     
     static let V8_BROADLOG_ID = UUID().uuidString
     var mockNetwork: MockNetworking!

--- a/AEPCampaignClassic/Tests/FunctionalTests/CampaignClassicIntegrationTests.swift
+++ b/AEPCampaignClassic/Tests/FunctionalTests/CampaignClassicIntegrationTests.swift
@@ -17,7 +17,7 @@ import AEPCampaignClassic
 import Foundation
 import XCTest
 
-class CampaignClassicFunctionalTests: XCTestCase {
+class CampaignClassicIntegrationTests: XCTestCase {
     
     // Configuration test constants
     static let TRACKING_SERVER = "trackserver"

--- a/AEPCampaignClassic/Tests/UnitTests/CampaignClassicPublicAPITests.swift
+++ b/AEPCampaignClassic/Tests/UnitTests/CampaignClassicPublicAPITests.swift
@@ -17,7 +17,7 @@ import XCTest
 class CampaignClassicPublicAPITests: XCTestCase {
     
     let SAMPLE_PUSHTOKEN_DATA = "PushToken".data(using: .utf8)!
-    let SAMPLE_PUSHTOKEN_AS_HEXSTRING = "50757368546F6B656E"
+    let SAMPLE_PUSHTOKEN_AS_HEXSTRING = "50757368546f6b656e"
     let SAMPLE_INFO : [String : String] = ["key" : "value"]
     
 
@@ -61,7 +61,31 @@ class CampaignClassicPublicAPITests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
     
-    
+    func test_registerDevice_withNilUserKeyAndAdditionalData() throws {
+        let expectation = XCTestExpectation(description: "Register Device API should dispatch appropriate event")
+        
+        // event dispatch verification
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: EventType.campaign,
+                                                                                    source: EventSource.requestContent) { event in
+            // unwrap optionals
+            let isRegisterDeviceEvent = try? XCTUnwrap(event.data?[TestConstants.EventDataKeys.CampaignClassic.REGISTER_DEVICE] as? Bool)
+            let userKey = try? XCTUnwrap(event.data?[TestConstants.EventDataKeys.CampaignClassic.USER_KEY] as? String)
+            
+            // verify
+            XCTAssertEqual(isRegisterDeviceEvent, true)
+            XCTAssertEqual("", userKey)
+            XCTAssertNil(event.data?[TestConstants.EventDataKeys.CampaignClassic.ADDITIONAL_PARAMETERS] as? [String : AnyCodable])
+               
+            expectation.fulfill()
+        }
+        
+        // test
+        CampaignClassic.registerDevice(token: SAMPLE_PUSHTOKEN_DATA, userKey: nil, additionalParameters: nil)
+        
+        // verify
+        wait(for: [expectation], timeout: 1)
+    }
+        
     func test_trackNotificationClick() throws {
         let expectation = XCTestExpectation(description: "CampaignClassic Track Notification Click should dispatch appropriate event")
         

--- a/AEPCampaignClassic/Tests/UnitTests/CampaignClassicTests.swift
+++ b/AEPCampaignClassic/Tests/UnitTests/CampaignClassicTests.swift
@@ -28,7 +28,7 @@ class CampaignClassicTests: XCTestCase {
     static let V8_BROADLOG_ID = UUID().uuidString
     static let V7_BROADLOG_ID = "55336"
     static let DELIVERY_ID = "deliveryId"
-    let v7BROADLOG_ID_HEX = "D828"
+    let v7BROADLOG_ID_HEX = "d828"
       
     // instance variables
     let runtime = TestableExtensionRuntime()


### PR DESCRIPTION
Important changes
- Public API change that makes userkey optional
- Convert pushtoken into hex with smallCases (instead of upper case)
- Log the response message from CampaignServers to note for success or Error despite of 200 OK


Also included 
- Unit Test updates for the above