### PR TITLE
Update pod, remove Lifecycle dependency and import UIKit

### DIFF
--- a/AEPCampaignClassic/Sources/RegistrationManager.swift
+++ b/AEPCampaignClassic/Sources/RegistrationManager.swift
@@ -13,6 +13,7 @@
 import Foundation
 import AEPServices
 import AEPCore
+import UIKit
 
 ///
 /// Manages Campaign Classic device registration requests.

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     targets: [
         .target(name: "AEPCampaignClassic",
-                dependencies: ["AEPCore", .product(name: "AEPServices", package: "AEPCore"), .product(name: "AEPLifecycle", package: "AEPCore")],
+                dependencies: ["AEPCore", .product(name: "AEPServices", package: "AEPCore")],
                 path: "AEPCampaignClassic/Sources")
     ]
 )

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,11 +2,11 @@ PODS:
   - AEPAssurance (3.0.1):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.6.0):
+  - AEPCore (3.7.1):
     - AEPRulesEngine (>= 1.1.0)
-    - AEPServices (>= 3.6.0)
+    - AEPServices (>= 3.7.1)
   - AEPRulesEngine (1.2.0)
-  - AEPServices (3.6.0)
+  - AEPServices (3.7.1)
   - SwiftLint (0.44.0)
 
 DEPENDENCIES:
@@ -25,9 +25,9 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
-  AEPCore: 03a89f8b792a74e17f739ab535982569d6639b76
+  AEPCore: 412fe933382892ab6c6af958d2f69ebcbca11216
   AEPRulesEngine: 71228dfdac24c9ded09be13e3257a7eb22468ccc
-  AEPServices: fd41aa2d0eda1e6939ae00a99f8431a57d09e1ca
+  AEPServices: 7284c30359c789cd16bf366b4ea81094a66d21ab
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
 PODFILE CHECKSUM: 20a0fb1ffcab557b00c4ed434e3cc998df65cf88


### PR DESCRIPTION
- Update pods to point to latest core
- Remove Lifecycle dependency from Swift package
- Import UIKit to access UIDevice class