### PR TITLE
Support dynamic tracking endpoints based on instance name (_iNm)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,13 +53,14 @@ commands:
     steps:
       - macos/preboot-simulator:
           platform: "iOS"
-          version: "17.2"
-          device: "iPhone 15"
+          version: "18.5"
+          device: "iPhone 16"
 
 jobs:
   validate-code:
+    resource_class: m4pro.medium
     macos:
-      xcode: 15.1.0 # Specify the Xcode version to use
+      xcode: 16.4.0 # Specify the Xcode version to use
 
     steps:
       - checkout
@@ -76,8 +77,9 @@ jobs:
 
 
   test-ios:
+    resource_class: m4pro.medium
     macos:
-      xcode: 15.1.0 # Specify the Xcode version to use
+      xcode: 16.4.0 # Specify the Xcode version to use
 
     steps:
       - checkout
@@ -97,9 +99,10 @@ jobs:
       #     upload_name: Coverage Report for AEPCampaignClassic iOS Tests
       #     xtra_args: -c -v --xc --xp build/AEPCampaignClassic.xcresult
 
-  test-spm-podspec-archive:  
+  test-spm-podspec-archive:
+    resource_class: m4pro.medium
     macos:
-      xcode: 15.0 # Specify the Xcode version to use
+      xcode: 16.4.0 # Specify the Xcode version to use
     
     steps:
       - checkout

--- a/AEPCampaignClassic/Sources/CampaignClassic.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassic.swift
@@ -104,6 +104,8 @@ public class CampaignClassic: NSObject, Extension {
     /// If Configuration is not available or Campaign Classic is not configured, no track request shall be sent.
     /// Tracking identifiers messageId (_mId) and deliveryId (_dId), retrieved from the message payload, are
     /// required for track request to be sent.
+    /// If an instanceName (_iNm) is provided in the tracking info and a matching endpoint exists in the
+    /// trackingEndpointMapping configuration, that endpoint will be used instead of the default tracking server.
     ///
     /// - Parameters:
     ///   - event : the incoming track event
@@ -140,7 +142,17 @@ public class CampaignClassic: NSObject, Extension {
             return
         }
 
-        guard let trackingUrl = URL(string: String(format: CampaignClassicConstants.TRACKING_API_URL_BASE, trackingServer, transformedBroadlogId, deliveryId, tagId)) else {
+        // Determine the tracking endpoint based on instanceName and trackingEndpointsMap
+        let instanceName = event.instanceName
+        let trackEndpoint: String
+        if let instanceName = instanceName, let mappedEndpoint = configuration.trackingEndpointsMap?[instanceName] {
+            trackEndpoint = mappedEndpoint
+            Log.debug(label: CampaignClassicConstants.LOG_TAG, "Using mapped tracking endpoint for instanceName '\(instanceName)': \(trackEndpoint)")
+        } else {
+            trackEndpoint = trackingServer
+        }
+
+        guard let trackingUrl = URL(string: String(format: CampaignClassicConstants.TRACKING_API_URL_BASE, trackEndpoint, transformedBroadlogId, deliveryId, tagId)) else {
             Log.debug(label: CampaignClassicConstants.LOG_TAG, "Unable to process TrackNotification request, Unable to form a valid trackingURL.")
             return
         }

--- a/AEPCampaignClassic/Sources/CampaignClassic.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassic.swift
@@ -150,6 +150,7 @@ public class CampaignClassic: NSObject, Extension {
             Log.debug(label: CampaignClassicConstants.LOG_TAG, "Using mapped tracking endpoint for instanceName '\(instanceName)': \(trackEndpoint)")
         } else {
             trackEndpoint = trackingServer
+            Log.debug(label: CampaignClassicConstants.LOG_TAG, "Using default tracking server: \(trackingServer) (instanceName: \(String(describing: instanceName)))")
         }
 
         guard let trackingUrl = URL(string: String(format: CampaignClassicConstants.TRACKING_API_URL_BASE, trackEndpoint, transformedBroadlogId, deliveryId, tagId)) else {

--- a/AEPCampaignClassic/Sources/CampaignClassicConfiguration.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassicConfiguration.swift
@@ -47,10 +47,22 @@ struct CampaignClassicConfiguration {
         return trackingServer
     }
 
-    /// Returns the configured CampaignClassic's tracking endpoint mapping
-    /// Returns nil if the value is not found in configuration or not of type [String: String]
+    /// Returns the configured CampaignClassic's tracking endpoint mapping as [identifier: endpoint].
+    /// The config value is a JSON string: "[{\"identifier\":\"...\",\"endpoint\":\"...\"}]"
+    /// Returns nil if the value is missing or cannot be parsed.
     var trackingEndpointsMap: [String: String]? {
-        configSharedState?[CampaignClassicConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING] as? [String: String]
+        guard let jsonString = configSharedState?[CampaignClassicConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING] as? String,
+              let data = jsonString.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: String]] else {
+            return nil
+        }
+        var map = [String: String]()
+        for entry in array {
+            if let identifier = entry["identifier"], let endpoint = entry["endpoint"] {
+                map[identifier] = endpoint
+            }
+        }
+        return map.isEmpty ? nil : map
     }
 
     /// Returns the configured CampaignClassics's network timeout

--- a/AEPCampaignClassic/Sources/CampaignClassicConfiguration.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassicConfiguration.swift
@@ -47,6 +47,12 @@ struct CampaignClassicConfiguration {
         return trackingServer
     }
 
+    /// Returns the configured CampaignClassic's tracking endpoint mapping
+    /// Returns nil if the value is not found in configuration or not of type [String: String]
+    var trackingEndpointsMap: [String: String]? {
+        configSharedState?[CampaignClassicConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING] as? [String: String]
+    }
+
     /// Returns the configured CampaignClassics's network timeout
     /// Return default timeout, if the value is not found in configuration, or not of type Int
     var timeout: TimeInterval {

--- a/AEPCampaignClassic/Sources/CampaignClassicConstants.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassicConstants.swift
@@ -63,6 +63,7 @@ enum CampaignClassicConstants {
             static let TRACK_INFO = "trackinfo"
             static let TRACK_INFO_KEY_DELIVERY_ID = "_dId"
             static let TRACK_INFO_KEY_BROADLOG_ID = "_mId"
+            static let TRACK_INFO_KEY_INSTANCE_NAME = "_iNm"
         }
 
         enum Configuration {
@@ -72,6 +73,7 @@ enum CampaignClassicConstants {
             static let CAMPAIGNCLASSIC_MARKETING_SERVER = "campaignclassic.marketingServer"
             static let CAMPAIGNCLASSIC_TRACKING_SERVER = "campaignclassic.trackingServer"
             static let CAMPAIGNCLASSIC_INTEGRATION_KEY = "campaignclassic.ios.integrationKey"
+            static let CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING = "campaignclassic.trackingEndpointMapping"
         }
 
     }

--- a/AEPCampaignClassic/Sources/CampaignClassicConstants.swift
+++ b/AEPCampaignClassic/Sources/CampaignClassicConstants.swift
@@ -73,7 +73,7 @@ enum CampaignClassicConstants {
             static let CAMPAIGNCLASSIC_MARKETING_SERVER = "campaignclassic.marketingServer"
             static let CAMPAIGNCLASSIC_TRACKING_SERVER = "campaignclassic.trackingServer"
             static let CAMPAIGNCLASSIC_INTEGRATION_KEY = "campaignclassic.ios.integrationKey"
-            static let CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING = "campaignclassic.trackingEndpointMapping"
+            static let CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING = "campaignclassic.trackingEndpointsMapping"
         }
 
     }

--- a/AEPCampaignClassic/Sources/Extensions/Event+CampaignClassic.swift
+++ b/AEPCampaignClassic/Sources/Extensions/Event+CampaignClassic.swift
@@ -47,6 +47,14 @@ extension Event {
         return deliveryId
     }
 
+    /// Retrieves the instance name string from the event data if available and not empty, nil otherwise
+    var instanceName: String? {
+        guard let instanceName = trackingInfo?[CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_INSTANCE_NAME] as? String, !instanceName.isEmpty else {
+            return nil
+        }
+        return instanceName
+    }
+
     /// Retrieves the deviceToken string from the event data if available and not empty, nil otherwise
     var deviceToken: String? {
         guard let deviceToken = data?[CampaignClassicConstants.EventDataKeys.CampaignClassic.DEVICE_TOKEN] as? String, !deviceToken.isEmpty else {

--- a/AEPCampaignClassic/Tests/FunctionalTests/CampaignClassicIntegrationTests.swift
+++ b/AEPCampaignClassic/Tests/FunctionalTests/CampaignClassicIntegrationTests.swift
@@ -22,8 +22,13 @@ class CampaignClassicIntegrationTests: XCTestCase {
     // Configuration test constants
     static let TRACKING_SERVER = "trackserver"
     static let MARKETING_SERVER = "marketingServer"
+    static let RT_SERVER = "rtserver"
     static let INTEGRATION_KEY = "integrationKey"
     static let NETWORK_TIMEOUT = 10
+    
+    // Instance name test constants
+    static let MARKETING_INSTANCE_NAME = "marketing_mid_prod"
+    static let RT_INSTANCE_NAME = "rt_mid_prod"
 
     // broadLogID and deliveryID test constants
     let V8_BROADLOG_ID = UUID().uuidString
@@ -527,6 +532,129 @@ class CampaignClassicIntegrationTests: XCTestCase {
         XCTAssertEqual(2, mockNetwork.cachedNetworkRequests.count)
     }
 
+    //*******************************************************************
+    // Tracking Endpoint Mapping Tests
+    //*******************************************************************
+    
+    func test_trackNotificationClick_withoutInstanceName_usesDefaultTrackingServer() {
+        // setup
+        initExtensionsAndWait()
+        let endpointMapping = [
+            CampaignClassicIntegrationTests.MARKETING_INSTANCE_NAME: CampaignClassicIntegrationTests.MARKETING_SERVER,
+            CampaignClassicIntegrationTests.RT_INSTANCE_NAME: CampaignClassicIntegrationTests.RT_SERVER
+        ]
+        setConfiguration(trackingEndpointMapping: endpointMapping)
+        
+        let expectedURL = "https://trackserver/r/?id=h\(V8_BROADLOG_ID),deliveryId,2"
+        mockNetwork.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - payload without _iNm
+        CampaignClassic.trackNotificationClick(withUserInfo: ["_mId": V8_BROADLOG_ID, "_dId": DELIVERY_ID])
+
+        // verify - should use default tracking server
+        wait(for: [mockNetwork.connectAsyncCalled], timeout: ASYNC_TIMEOUT)
+        XCTAssertEqual(1, mockNetwork.cachedNetworkRequests.count)
+        XCTAssertEqual(expectedURL, mockNetwork.cachedNetworkRequests[0].url.absoluteString)
+    }
+    
+    func test_trackNotificationClick_withMarketingInstanceName_usesMarketingServer() {
+        // setup
+        initExtensionsAndWait()
+        let endpointMapping = [
+            CampaignClassicIntegrationTests.MARKETING_INSTANCE_NAME: CampaignClassicIntegrationTests.MARKETING_SERVER,
+            CampaignClassicIntegrationTests.RT_INSTANCE_NAME: CampaignClassicIntegrationTests.RT_SERVER
+        ]
+        setConfiguration(trackingEndpointMapping: endpointMapping)
+        
+        let expectedURL = "https://\(CampaignClassicIntegrationTests.MARKETING_SERVER)/r/?id=h\(V8_BROADLOG_ID),deliveryId,2"
+        mockNetwork.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - payload with marketing instance name
+        CampaignClassic.trackNotificationClick(withUserInfo: [
+            "_mId": V8_BROADLOG_ID,
+            "_dId": DELIVERY_ID,
+            "_iNm": CampaignClassicIntegrationTests.MARKETING_INSTANCE_NAME
+        ])
+
+        // verify - should use marketing server from mapping
+        wait(for: [mockNetwork.connectAsyncCalled], timeout: ASYNC_TIMEOUT)
+        XCTAssertEqual(1, mockNetwork.cachedNetworkRequests.count)
+        XCTAssertEqual(expectedURL, mockNetwork.cachedNetworkRequests[0].url.absoluteString)
+    }
+    
+    func test_trackNotificationClick_withRTInstanceName_usesRTServer() {
+        // setup
+        initExtensionsAndWait()
+        let endpointMapping = [
+            CampaignClassicIntegrationTests.MARKETING_INSTANCE_NAME: CampaignClassicIntegrationTests.MARKETING_SERVER,
+            CampaignClassicIntegrationTests.RT_INSTANCE_NAME: CampaignClassicIntegrationTests.RT_SERVER
+        ]
+        setConfiguration(trackingEndpointMapping: endpointMapping)
+        
+        let expectedURL = "https://\(CampaignClassicIntegrationTests.RT_SERVER)/r/?id=h\(V8_BROADLOG_ID),deliveryId,2"
+        mockNetwork.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - payload with RT instance name
+        CampaignClassic.trackNotificationClick(withUserInfo: [
+            "_mId": V8_BROADLOG_ID,
+            "_dId": DELIVERY_ID,
+            "_iNm": CampaignClassicIntegrationTests.RT_INSTANCE_NAME
+        ])
+
+        // verify - should use RT server from mapping
+        wait(for: [mockNetwork.connectAsyncCalled], timeout: ASYNC_TIMEOUT)
+        XCTAssertEqual(1, mockNetwork.cachedNetworkRequests.count)
+        XCTAssertEqual(expectedURL, mockNetwork.cachedNetworkRequests[0].url.absoluteString)
+    }
+    
+    func test_trackNotificationClick_withUnknownInstanceName_usesDefaultTrackingServer() {
+        // setup
+        initExtensionsAndWait()
+        let endpointMapping = [
+            CampaignClassicIntegrationTests.MARKETING_INSTANCE_NAME: CampaignClassicIntegrationTests.MARKETING_SERVER,
+            CampaignClassicIntegrationTests.RT_INSTANCE_NAME: CampaignClassicIntegrationTests.RT_SERVER
+        ]
+        setConfiguration(trackingEndpointMapping: endpointMapping)
+        
+        let expectedURL = "https://trackserver/r/?id=h\(V8_BROADLOG_ID),deliveryId,2"
+        mockNetwork.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - payload with unknown instance name
+        CampaignClassic.trackNotificationClick(withUserInfo: [
+            "_mId": V8_BROADLOG_ID,
+            "_dId": DELIVERY_ID,
+            "_iNm": "unknown_instance"
+        ])
+
+        // verify - should fallback to default tracking server
+        wait(for: [mockNetwork.connectAsyncCalled], timeout: ASYNC_TIMEOUT)
+        XCTAssertEqual(1, mockNetwork.cachedNetworkRequests.count)
+        XCTAssertEqual(expectedURL, mockNetwork.cachedNetworkRequests[0].url.absoluteString)
+    }
+    
+    func test_trackNotificationReceive_withMarketingInstanceName_usesMarketingServer() {
+        // setup
+        initExtensionsAndWait()
+        let endpointMapping = [
+            CampaignClassicIntegrationTests.MARKETING_INSTANCE_NAME: CampaignClassicIntegrationTests.MARKETING_SERVER
+        ]
+        setConfiguration(trackingEndpointMapping: endpointMapping)
+        
+        let expectedURL = "https://\(CampaignClassicIntegrationTests.MARKETING_SERVER)/r/?id=h\(V8_BROADLOG_ID),deliveryId,1"
+        mockNetwork.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - receive event with marketing instance name
+        CampaignClassic.trackNotificationReceive(withUserInfo: [
+            "_mId": V8_BROADLOG_ID,
+            "_dId": DELIVERY_ID,
+            "_iNm": CampaignClassicIntegrationTests.MARKETING_INSTANCE_NAME
+        ])
+
+        // verify - should use marketing server from mapping
+        wait(for: [mockNetwork.connectAsyncCalled], timeout: ASYNC_TIMEOUT)
+        XCTAssertEqual(1, mockNetwork.cachedNetworkRequests.count)
+        XCTAssertEqual(expectedURL, mockNetwork.cachedNetworkRequests[0].url.absoluteString)
+    }
 
     //*******************************************************************
     // private verifiers
@@ -554,12 +682,23 @@ class CampaignClassicIntegrationTests: XCTestCase {
                                   integrationKey: String? = INTEGRATION_KEY,
                                   trackingServer : String? = TRACKING_SERVER,
                                   privacyStatus : String = PrivacyStatus.optedIn.rawValue,
-                                  networkTimeout : Int = NETWORK_TIMEOUT) {
-        let config = [ TestConstants.EventDataKeys.Configuration.GLOBAL_CONFIG_PRIVACY: privacyStatus,
-                       TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_SERVER: trackingServer as Any,
-                       TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_MARKETING_SERVER: marketingServer as Any,
-                       TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_INTEGRATION_KEY: integrationKey as Any,
-                       TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_NETWORK_TIMEOUT: networkTimeout]
+                                  networkTimeout : Int = NETWORK_TIMEOUT,
+                                  trackingEndpointMapping: [String: String]? = nil) {
+        var config: [String: Any] = [
+            TestConstants.EventDataKeys.Configuration.GLOBAL_CONFIG_PRIVACY: privacyStatus,
+            TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_SERVER: trackingServer as Any,
+            TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_MARKETING_SERVER: marketingServer as Any,
+            TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_INTEGRATION_KEY: integrationKey as Any,
+            TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_NETWORK_TIMEOUT: networkTimeout
+        ]
+        if let trackingEndpointMapping = trackingEndpointMapping {
+            // Config value is a JSON string: "[{\"identifier\":\"...\",\"endpoint\":\"...\"}]"
+            let array = trackingEndpointMapping.map { ["identifier": $0.key, "endpoint": $0.value] }
+            if let jsonData = try? JSONSerialization.data(withJSONObject: array),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                config[TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING] = jsonString
+            }
+        }
         MobileCore.updateConfigurationWith(configDict: config)
         sleep(2)
     }

--- a/AEPCampaignClassic/Tests/TestHelpers/TestConstants.swift
+++ b/AEPCampaignClassic/Tests/TestHelpers/TestConstants.swift
@@ -54,6 +54,7 @@ enum TestConstants {
             static let TRACK_INFO = "trackinfo"
             static let TRACK_INFO_KEY_DELIVERY_ID = "_dId"
             static let TRACK_INFO_KEY_BROADLOG_ID = "_mId"
+            static let TRACK_INFO_KEY_INSTANCE_NAME = "_iNm"
         }
 
         enum Configuration {
@@ -63,6 +64,7 @@ enum TestConstants {
             static let CAMPAIGNCLASSIC_MARKETING_SERVER = "campaignclassic.marketingServer"
             static let CAMPAIGNCLASSIC_TRACKING_SERVER = "campaignclassic.trackingServer"
             static let CAMPAIGNCLASSIC_INTEGRATION_KEY = "campaignclassic.ios.integrationKey"
+            static let CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING = "campaignclassic.trackingEndpointMapping"
         }
 
     }

--- a/AEPCampaignClassic/Tests/TestHelpers/TestConstants.swift
+++ b/AEPCampaignClassic/Tests/TestHelpers/TestConstants.swift
@@ -64,7 +64,7 @@ enum TestConstants {
             static let CAMPAIGNCLASSIC_MARKETING_SERVER = "campaignclassic.marketingServer"
             static let CAMPAIGNCLASSIC_TRACKING_SERVER = "campaignclassic.trackingServer"
             static let CAMPAIGNCLASSIC_INTEGRATION_KEY = "campaignclassic.ios.integrationKey"
-            static let CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING = "campaignclassic.trackingEndpointMapping"
+            static let CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING = "campaignclassic.trackingEndpointsMapping"
         }
 
     }

--- a/AEPCampaignClassic/Tests/UnitTests/CampaignClassicTests.swift
+++ b/AEPCampaignClassic/Tests/UnitTests/CampaignClassicTests.swift
@@ -21,8 +21,13 @@ class CampaignClassicTests: XCTestCase {
     // Configuration test constants
     static let TRACKING_SERVER = "trackserver"
     static let MARKETING_SERVER = "marketingServer"
+    static let RT_SERVER = "rtserver"
     static let INTEGRATION_KEY = "integrationKey"
     static let NETWORK_TIMEOUT = 10
+    
+    // Instance name test constants
+    static let MARKETING_INSTANCE_NAME = "marketing_mid_prod"
+    static let RT_INSTANCE_NAME = "rt_mid_prod"
     
     // broadLogID and deliveryID test constants
     static let V8_BROADLOG_ID = UUID().uuidString
@@ -224,6 +229,103 @@ class CampaignClassicTests: XCTestCase {
     }
     
     //*******************************************************************
+    // Tracking Endpoint Mapping Tests
+    //*******************************************************************
+    func test_trackNotificationClick_withoutInstanceName_fallbackToDefaultEndpoint() throws {
+        // setup - no instanceName in payload, should use default tracking server
+        let expectedURL = "https://trackserver/r/?id=h\(CampaignClassicTests.V8_BROADLOG_ID),deliveryId,2"
+        let endpointMapping = [
+            CampaignClassicTests.MARKETING_INSTANCE_NAME: CampaignClassicTests.MARKETING_SERVER,
+            CampaignClassicTests.RT_INSTANCE_NAME: CampaignClassicTests.RT_SERVER
+        ]
+        setConfigState(trackingEndpointMapping: endpointMapping)
+        networking.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - event without instanceName
+        runtime.simulateComingEvents(trackNotificationClickEvent())
+        
+        // verify - should use default trackserver
+        wait(for: [networking.connectAsyncCalled], timeout: 1)
+        XCTAssertEqual(networking.cachedNetworkRequests.count, 1)
+        XCTAssertEqual(networking.cachedNetworkRequests[0].url.absoluteString, expectedURL)
+    }
+    
+    func test_trackNotificationClick_withMarketingInstanceName_sendsToMarketingServer() throws {
+        // setup - instanceName matches marketing server in mapping
+        let expectedURL = "https://\(CampaignClassicTests.MARKETING_SERVER)/r/?id=h\(CampaignClassicTests.V8_BROADLOG_ID),deliveryId,2"
+        let endpointMapping = [
+            CampaignClassicTests.MARKETING_INSTANCE_NAME: CampaignClassicTests.MARKETING_SERVER,
+            CampaignClassicTests.RT_INSTANCE_NAME: CampaignClassicTests.RT_SERVER
+        ]
+        setConfigState(trackingEndpointMapping: endpointMapping)
+        networking.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - event with marketing instanceName
+        runtime.simulateComingEvents(trackNotificationClickEvent(instanceName: CampaignClassicTests.MARKETING_INSTANCE_NAME))
+        
+        // verify - should use marketing server
+        wait(for: [networking.connectAsyncCalled], timeout: 1)
+        XCTAssertEqual(networking.cachedNetworkRequests.count, 1)
+        XCTAssertEqual(networking.cachedNetworkRequests[0].url.absoluteString, expectedURL)
+    }
+    
+    func test_trackNotificationClick_withRTInstanceName_sendsToRTServer() throws {
+        // setup - instanceName matches RT server in mapping
+        let expectedURL = "https://\(CampaignClassicTests.RT_SERVER)/r/?id=h\(CampaignClassicTests.V8_BROADLOG_ID),deliveryId,2"
+        let endpointMapping = [
+            CampaignClassicTests.MARKETING_INSTANCE_NAME: CampaignClassicTests.MARKETING_SERVER,
+            CampaignClassicTests.RT_INSTANCE_NAME: CampaignClassicTests.RT_SERVER
+        ]
+        setConfigState(trackingEndpointMapping: endpointMapping)
+        networking.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - event with RT instanceName
+        runtime.simulateComingEvents(trackNotificationClickEvent(instanceName: CampaignClassicTests.RT_INSTANCE_NAME))
+        
+        // verify - should use RT server
+        wait(for: [networking.connectAsyncCalled], timeout: 1)
+        XCTAssertEqual(networking.cachedNetworkRequests.count, 1)
+        XCTAssertEqual(networking.cachedNetworkRequests[0].url.absoluteString, expectedURL)
+    }
+    
+    func test_trackNotificationClick_withUnknownInstanceName_fallbackToDefaultEndpoint() throws {
+        // setup - instanceName not found in mapping, should fallback to default
+        let expectedURL = "https://trackserver/r/?id=h\(CampaignClassicTests.V8_BROADLOG_ID),deliveryId,2"
+        let endpointMapping = [
+            CampaignClassicTests.MARKETING_INSTANCE_NAME: CampaignClassicTests.MARKETING_SERVER,
+            CampaignClassicTests.RT_INSTANCE_NAME: CampaignClassicTests.RT_SERVER
+        ]
+        setConfigState(trackingEndpointMapping: endpointMapping)
+        networking.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - event with unknown instanceName
+        runtime.simulateComingEvents(trackNotificationClickEvent(instanceName: "unknown_instance"))
+        
+        // verify - should fallback to default trackserver
+        wait(for: [networking.connectAsyncCalled], timeout: 1)
+        XCTAssertEqual(networking.cachedNetworkRequests.count, 1)
+        XCTAssertEqual(networking.cachedNetworkRequests[0].url.absoluteString, expectedURL)
+    }
+    
+    func test_trackNotificationReceive_withMarketingInstanceName_sendsToMarketingServer() throws {
+        // setup - verify receive events also use endpoint mapping
+        let expectedURL = "https://\(CampaignClassicTests.MARKETING_SERVER)/r/?id=h\(CampaignClassicTests.V8_BROADLOG_ID),deliveryId,1"
+        let endpointMapping = [
+            CampaignClassicTests.MARKETING_INSTANCE_NAME: CampaignClassicTests.MARKETING_SERVER
+        ]
+        setConfigState(trackingEndpointMapping: endpointMapping)
+        networking.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: URL(string: expectedURL)!, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        // test - receive event with marketing instanceName
+        runtime.simulateComingEvents(trackNotificationReceiveEvent(instanceName: CampaignClassicTests.MARKETING_INSTANCE_NAME))
+        
+        // verify - should use marketing server
+        wait(for: [networking.connectAsyncCalled], timeout: 1)
+        XCTAssertEqual(networking.cachedNetworkRequests.count, 1)
+        XCTAssertEqual(networking.cachedNetworkRequests[0].url.absoluteString, expectedURL)
+    }
+    
+    //*******************************************************************
     // Register Device Tests
     //*******************************************************************
     func test_registerDevice() throws {
@@ -271,8 +373,11 @@ class CampaignClassicTests: XCTestCase {
     // private methods
     //*******************************************************************
     
-    private func trackNotificationClickEvent(broadLogID : String? = V8_BROADLOG_ID, deliveryID : String? = DELIVERY_ID) -> Event {
-        let userInfo = ["_mId" : broadLogID, "_dId" : deliveryID]
+    private func trackNotificationClickEvent(broadLogID : String? = V8_BROADLOG_ID, deliveryID : String? = DELIVERY_ID, instanceName: String? = nil) -> Event {
+        var userInfo: [String: Any?] = ["_mId" : broadLogID, "_dId" : deliveryID]
+        if let instanceName = instanceName {
+            userInfo["_iNm"] = instanceName
+        }
         return Event(name: TestConstants.EventName.TRACK_NOTIFICATION_CLICK,
                      type: EventType.campaign,
                      source: EventSource.requestContent,
@@ -280,8 +385,11 @@ class CampaignClassicTests: XCTestCase {
                             TestConstants.EventDataKeys.CampaignClassic.TRACK_INFO: userInfo] as [String: Any])
     }
     
-    private func trackNotificationReceiveEvent(broadLogID : String = V8_BROADLOG_ID, deliveryID : String? = DELIVERY_ID) -> Event {
-        let userInfo = ["_mId" : broadLogID, "_dId" : deliveryID]
+    private func trackNotificationReceiveEvent(broadLogID : String = V8_BROADLOG_ID, deliveryID : String? = DELIVERY_ID, instanceName: String? = nil) -> Event {
+        var userInfo: [String: Any?] = ["_mId" : broadLogID, "_dId" : deliveryID]
+        if let instanceName = instanceName {
+            userInfo["_iNm"] = instanceName
+        }
         return Event(name: TestConstants.EventName.TRACK_NOTIFICATION_CLICK,
                      type: EventType.campaign,
                      source: EventSource.requestContent,
@@ -308,10 +416,14 @@ class CampaignClassicTests: XCTestCase {
     
     private func setConfigState(trackingServer : String? = TRACKING_SERVER,
                                 privacyStatus : String = PrivacyStatus.optedIn.rawValue,
-                                networkTimeOut : Int = NETWORK_TIMEOUT) {
+                                networkTimeOut : Int = NETWORK_TIMEOUT,
+                                trackingEndpointMapping: [String: String]? = nil) {
         configurationSharedState = [ TestConstants.EventDataKeys.Configuration.GLOBAL_CONFIG_PRIVACY: privacyStatus,
                                      TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_SERVER: trackingServer as Any,
                                      TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_NETWORK_TIMEOUT: networkTimeOut]
+        if let trackingEndpointMapping = trackingEndpointMapping {
+            configurationSharedState[TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING] = trackingEndpointMapping
+        }
         runtime.simulateSharedState(for: TestConstants.EventDataKeys.Configuration.EXTENSION_NAME, data: (configurationSharedState, .set))
     }
 }

--- a/AEPCampaignClassic/Tests/UnitTests/CampaignClassicTests.swift
+++ b/AEPCampaignClassic/Tests/UnitTests/CampaignClassicTests.swift
@@ -422,7 +422,12 @@ class CampaignClassicTests: XCTestCase {
                                      TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_SERVER: trackingServer as Any,
                                      TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_NETWORK_TIMEOUT: networkTimeOut]
         if let trackingEndpointMapping = trackingEndpointMapping {
-            configurationSharedState[TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING] = trackingEndpointMapping
+            // Config value is a JSON string: "[{\"identifier\":\"...\",\"endpoint\":\"...\"}]"
+            let array = trackingEndpointMapping.map { ["identifier": $0.key, "endpoint": $0.value] }
+            if let jsonData = try? JSONSerialization.data(withJSONObject: array),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                configurationSharedState[TestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING] = jsonString
+            }
         }
         runtime.simulateSharedState(for: TestConstants.EventDataKeys.Configuration.EXTENSION_NAME, data: (configurationSharedState, .set))
     }


### PR DESCRIPTION
Support dynamic tracking endpoints based on instance name (_iNm) from push payload. If an instanceName is provided and exists in the trackingEndpointMapping configuration, the mapped endpoint is used; otherwise falls back to the default tracking server.

- Add trackingEndpointsMap property to CampaignClassicConfiguration
- Add instanceName property to Event extension to extract _iNm from tracking info
- Update handleTrackEvent to use mapped endpoint when available
- Add unit tests for all scenarios (marketing server, RT server, fallback)

Made-with: Cursor

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
